### PR TITLE
Use http by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for kubepy
 
 - Set not provided and not required fields to None.
 - Removed pytest from dependencies.
+- Use HTTP instead of gRPC by default, allow to pick gRPC instead in configuration.
 
 
 0.1.0 (2017-01-25)

--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,5 +1,5 @@
 cached_property
-google-cloud-pubsub
+google-cloud-pubsub>=0.24
 marshmallow
 netaddr
 tenacity

--- a/queue_messaging/configuration.py
+++ b/queue_messaging/configuration.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 Configuration = namedtuple(
     'Configuration',
     ['TOPIC', 'SUBSCRIPTION', 'DEAD_LETTER_TOPIC', 'PUBSUB_EMULATOR_HOST',
-     'MESSAGE_TYPES'],
+     'MESSAGE_TYPES', 'USE_GRPC'],
 )
 
 
@@ -19,4 +19,5 @@ class Factory:
             self.config_dict.get('DEAD_LETTER_TOPIC'),
             self.config_dict.get('PUBSUB_EMULATOR_HOST'),
             self.config_dict.get('MESSAGE_TYPES', []),
+            self.config_dict.get('USE_GRPC', False),
         )

--- a/queue_messaging/services/pubsub.py
+++ b/queue_messaging/services/pubsub.py
@@ -15,6 +15,7 @@ def get_pubsub_client(queue_config):
         topic_name=queue_config.TOPIC,
         subscription_name=queue_config.SUBSCRIPTION,
         pubsub_emulator_host=queue_config.PUBSUB_EMULATOR_HOST,
+        use_grpc=queue_config.USE_GRPC,
     )
 
 
@@ -23,6 +24,7 @@ def get_fallback_pubsub_client(queue_config):
         topic_name=queue_config.DEAD_LETTER_TOPIC,
         subscription_name=queue_config.SUBSCRIPTION,
         pubsub_emulator_host=queue_config.PUBSUB_EMULATOR_HOST,
+        use_grpc=queue_config.USE_GRPC,
     )
 
 
@@ -39,10 +41,12 @@ class PubSub:
     def __init__(self,
                  topic_name,
                  subscription_name=None,
-                 pubsub_emulator_host=None):
+                 pubsub_emulator_host=None,
+                 use_grpc=False):
         self.topic_name = topic_name
         self.subscription_name = subscription_name
         self.pubsub_emulator_host = pubsub_emulator_host
+        self.use_grpc = use_grpc
 
     @cached_property
     def topic(self):
@@ -56,9 +60,9 @@ class PubSub:
     def client(self):
         if self.pubsub_emulator_host:
             with utils.EnvironmentContext('PUBSUB_EMULATOR_HOST', self.pubsub_emulator_host):
-                return pubsub.Client(_http=httplib2.Http())
+                return pubsub.Client(_http=httplib2.Http(), _use_grpc=self.use_grpc)
         else:
-            return pubsub.Client()
+            return pubsub.Client(_use_grpc=self.use_grpc)
 
     @retry
     def send(self, message: str, **attributes):

--- a/queue_messaging/services/pubsub.py
+++ b/queue_messaging/services/pubsub.py
@@ -56,7 +56,7 @@ class PubSub:
     def client(self):
         if self.pubsub_emulator_host:
             with utils.EnvironmentContext('PUBSUB_EMULATOR_HOST', self.pubsub_emulator_host):
-                return pubsub.Client(http=httplib2.Http())
+                return pubsub.Client(_http=httplib2.Http())
         else:
             return pubsub.Client()
 


### PR DESCRIPTION
We've seen processes hang indefinitely without emitting warnings due to https://github.com/grpc/grpc/issues/8994
For now, it seems safer to use the HTTP transport by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/queue-messaging/4)
<!-- Reviewable:end -->
