### PR TITLE
Update pubsub handling for google-cloud-pubsub 0.32.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-Changelog for kubepy
+Changelog for queue-messaging
 =================
 
-0.2.1 (unreleased)
+0.3.0 (unreleased)
 ------------------
-
-- Nothing changed yet.
+- Backward incompatible update for latest google-cloud-pubsub compatiblity.
+   - PubSub message pulling becomes asynchronous
+   - messaging.receive instead of returning an Envelope with message now takes a callback to be called on Envelope
+   - google-cloud-pubsub will manage sleeping when pulling for new messages on its own
+   - Google Cloud project id is now required for pubsub configuration
 
 
 0.2 (2017-05-17)

--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,5 +1,7 @@
 cached_property
-google-cloud-pubsub>=0.24
+google-cloud-core
+google-cloud-pubsub>=0.32.1
+google-gax
 marshmallow
 netaddr
 tenacity

--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,7 +1,6 @@
 cached_property
 google-cloud-core
 google-cloud-pubsub>=0.32.1
-google-gax
 marshmallow
 netaddr
 tenacity

--- a/queue_messaging/configuration.py
+++ b/queue_messaging/configuration.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 Configuration = namedtuple(
     'Configuration',
     ['TOPIC', 'SUBSCRIPTION', 'DEAD_LETTER_TOPIC', 'PUBSUB_EMULATOR_HOST',
-     'MESSAGE_TYPES', 'USE_GRPC'],
+     'MESSAGE_TYPES', 'PROJECT_ID'],
 )
 
 
@@ -19,5 +19,5 @@ class Factory:
             self.config_dict.get('DEAD_LETTER_TOPIC'),
             self.config_dict.get('PUBSUB_EMULATOR_HOST'),
             self.config_dict.get('MESSAGE_TYPES', []),
-            self.config_dict.get('USE_GRPC', False),
+            self.config_dict.get('PROJECT_ID'),
         )

--- a/queue_messaging/data/structures.py
+++ b/queue_messaging/data/structures.py
@@ -50,4 +50,4 @@ class Model:
 
 
 PulledMessage = collections.namedtuple(
-    'PulledMessage', ['ack_id', 'data', 'message_id', 'attributes'])
+    'PulledMessage', ['ack', 'data', 'message_id', 'attributes'])

--- a/queue_messaging/services/pubsub.py
+++ b/queue_messaging/services/pubsub.py
@@ -3,7 +3,6 @@ import logging
 import tenacity
 from google.cloud import exceptions as google_cloud_exceptions
 from google.cloud import pubsub
-from google.gax import errors
 
 from queue_messaging import exceptions
 from queue_messaging import utils
@@ -32,7 +31,7 @@ def get_fallback_pubsub_client(queue_config):
 
 retry = tenacity.retry(
     retry=tenacity.retry_if_exception_type(
-        (errors.GaxError, ConnectionError)
+        (ConnectionError, google_cloud_exceptions.GoogleCloudError)
     ),
     stop=tenacity.stop_after_attempt(max_attempt_number=3),
     reraise=True,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 
 setup(
     name='queue-messaging',
-    version='0.2.1.dev0',
+    version='0.3.0.dev0',
     description='Python queue messaging library.',
     author='Jakub Trochim',
     author_email='it@socialwifi.com',

--- a/tests/services/test_pubsub.py
+++ b/tests/services/test_pubsub.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
+from google.cloud import exceptions as google_cloud_exceptions
 import pytest
-from google.gax import errors as gax_errors
 
 from queue_messaging.services import pubsub
 
@@ -125,9 +125,9 @@ class TestRetry:
         result = decorated()
         assert result == 1
 
-    def test_retrying_on_gax_error(self, mocked_function):
+    def test_retrying_on_google_cloud_error(self, mocked_function):
         mocked_function.side_effect = [
-            gax_errors.GaxError(msg="RPC failed"), 1
+            google_cloud_exceptions.GoogleCloudError('e'), 1
         ]
         decorated = pubsub.retry(mocked_function)
         result = decorated()

--- a/tests/services/test_pubsub.py
+++ b/tests/services/test_pubsub.py
@@ -8,52 +8,54 @@ from queue_messaging.services import pubsub
 
 class TestPubSub:
     def test_receive(self, pull_mock):
+        def callback(message):
+            assert message.message_id == 1
+
         valid_response = self.valid_response_factory(message_id=1)
-        pull_mock.return_value = valid_response
-        client = pubsub.PubSub(topic_name=mock.Mock())
-        message = client.receive()
-        assert message.message_id == 1
+        pull_mock.side_effect = callback(valid_response)
+        client = pubsub.PubSub(topic_name=mock.Mock(), project_id='')
+        client.receive(callback=callback)
+
+    def test_assert_in_receive_callback(self, pull_mock):
+        def callback(message):
+            assert message.message_id == 0
+
+        valid_response = self.valid_response_factory(message_id=1)
+        with pytest.raises(AssertionError):
+            pull_mock.side_effect = callback(valid_response)
+        client = pubsub.PubSub(topic_name=mock.Mock(), project_id='')
+        client.receive(callback=callback)
 
     def test_retrying_receive(self, pull_mock):
+        def callback(message):
+            assert message.message_id == 1
+
         valid_response = self.valid_response_factory(message_id=1)
         pull_mock.side_effect = [
-            ConnectionResetError, valid_response
+            ConnectionResetError, callback(valid_response)
         ]
-        client = pubsub.PubSub(topic_name=mock.Mock())
-        message = client.receive()
-        assert message.message_id == 1
+        client = pubsub.PubSub(topic_name=mock.Mock(), project_id='')
+        client.receive(callback=callback)
 
-    def test_send(self, publish_mock):
+    def test_send(self, publish_mock, topic_path_mock):
         publish_mock.return_value = '123'
-        client = pubsub.PubSub(topic_name=mock.Mock())
+        topic_path_mock.return_value = 'projects/p_id/topics/a-publisher'
+        client = pubsub.PubSub(topic_name='a-publisher', project_id='p_id')
         result = client.send(message='')
-        publish_mock.assert_called_with(b'')
+        publish_mock.assert_called_with('projects/p_id/topics/a-publisher', b'')
         assert result == '123'
 
     def test_retrying_send(self, publish_mock):
         publish_mock.side_effect = [
             ConnectionResetError, '123'
         ]
-        client = pubsub.PubSub(topic_name=mock.Mock())
+        client = pubsub.PubSub(topic_name='a-publisher', project_id='p_id')
         result = client.send(message='')
         assert result == '123'
 
-    def test_acknowledge(self, acknowledge_mock):
-        client = pubsub.PubSub(topic_name=mock.Mock())
-        client.acknowledge(msg_id='123')
-        acknowledge_mock.assert_called_with(['123'])
-
-    def test_retrying_acknowledge(self, acknowledge_mock):
-        acknowledge_mock.side_effect = [
-            ConnectionResetError, None
-        ]
-        client = pubsub.PubSub(topic_name=mock.Mock())
-        client.acknowledge(msg_id='123')
-        assert acknowledge_mock.call_count == 2
-
     @staticmethod
     def valid_response_factory(*, message_id=1):
-        message = mock.MagicMock(
+        return mock.MagicMock(
             data=(b'{"uuid_field": "cd1d3a03-7b04-4a35-97f8-ee5f3eb04c8e", '
                   b'"string_field": "Just testing!"}'),
             message_id=message_id,
@@ -62,17 +64,21 @@ class TestPubSub:
                 'type': 'FancyEvent',
             }
         )
-        return [(123, message)]
 
 
 @pytest.fixture
 def pull_mock(subscription_mock):
-    return subscription_mock.pull
+    return subscription_mock.open
 
 
 @pytest.fixture
-def publish_mock(topic_mock):
-    return topic_mock.publish
+def topic_path_mock(pubsub_publisher_client_mock):
+    return pubsub_publisher_client_mock.return_value.topic_path
+
+
+@pytest.fixture
+def publish_mock(pubsub_publisher_client_mock):
+    return pubsub_publisher_client_mock.return_value.publish
 
 
 @pytest.fixture
@@ -81,18 +87,24 @@ def acknowledge_mock(subscription_mock):
 
 
 @pytest.fixture
-def subscription_mock(topic_mock):
-    return topic_mock.subscription.return_value
+def subscription_mock(pubsub_client_mock):
+    return pubsub_client_mock.return_value.subscribe.return_value
 
 
 @pytest.fixture
-def topic_mock(pubsub_client_mock):
-    return pubsub_client_mock.return_value.topic.return_value
+def topic_mock(pubsub_publisher_client_mock):
+    return pubsub_publisher_client_mock.return_value.publisher
 
 
 @pytest.fixture
 def pubsub_client_mock():
-    with mock.patch('google.cloud.pubsub.Client') as client:
+    with mock.patch('google.cloud.pubsub.SubscriberClient') as client:
+        yield client
+
+
+@pytest.fixture
+def pubsub_publisher_client_mock():
+    with mock.patch('google.cloud.pubsub.PublisherClient') as client:
         yield client
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,8 +23,20 @@ class FancyEvent(queue_messaging.Model):
 
 @pytest.fixture()
 def pubsub_client_mock():
-    with mock.patch('google.cloud.pubsub.Client') as client:
+    with mock.patch('google.cloud.pubsub.SubscriberClient') as client:
         yield client
+
+
+@pytest.fixture()
+def pubsub_publisher_client_mock():
+    with mock.patch('google.cloud.pubsub.PublisherClient') as client:
+        yield client
+
+
+@pytest.fixture()
+def topic_path_mock():
+    with mock.patch('queue_messaging.services.pubsub.PubSub._get_topic_path') as path:
+        yield path
 
 
 @pytest.fixture()
@@ -33,9 +45,11 @@ def header_timestamp_mock():
         yield now_mock
 
 
-def test_send(header_timestamp_mock, pubsub_client_mock):
+def test_send(header_timestamp_mock, pubsub_publisher_client_mock, topic_path_mock):
+    topic_path_mock.return_value = 'projects/p-id/topics/test-topic'
     messaging = queue_messaging.Messaging.create_from_dict({
         'TOPIC': 'test-topic',
+        'PROJECT_ID': 'p-id',
     })
     model = FancyEvent(
         uuid_field=uuid.UUID('cd1d3a03-7b04-4a35-97f8-ee5f3eb04c8e'),
@@ -46,10 +60,10 @@ def test_send(header_timestamp_mock, pubsub_client_mock):
 
     messaging.send(model)
 
-    topic_mock = pubsub_client_mock.return_value.topic
-    publish_mock = topic_mock.return_value.publish
-    topic_mock.assert_called_with('test-topic')
+    publish_mock = pubsub_publisher_client_mock.return_value.publish
+    publish_mock.topic_path.return_value = 'z'
     publish_mock.assert_called_with(
+        'projects/p-id/topics/test-topic',
         test_utils.EncodedJson({
             "uuid_field": "cd1d3a03-7b04-4a35-97f8-ee5f3eb04c8e",
             "string_field": "Just testing!"
@@ -65,30 +79,9 @@ def test_receive(pubsub_client_mock):
         'MESSAGE_TYPES': [
             FancyEvent,
         ],
+        'PROJECT_ID': 'p-id',
     })
-    topic_mock = pubsub_client_mock.return_value.topic.return_value
-    subscription_mock = topic_mock.subscription.return_value
-    mocked_message = mock.MagicMock(
-        data=(b'{"uuid_field": "cd1d3a03-7b04-4a35-97f8-ee5f3eb04c8e", '
-              b'"string_field": "Just testing!"}'),
-        message_id=1,
-        attributes={
-            'timestamp': '2016-12-10T11:15:45.123456Z',
-            'type': 'FancyEvent',
-        }
-    )
-    subscription_mock.pull.return_value = [
-        (123, mocked_message)
-    ]
+    subscription_mock = pubsub_client_mock.return_value.subscribe.return_value
 
-    envelope = messaging.receive()
-
-    topic_mock.subscription.assert_called_with('test-subscription')
-    assert envelope.model == FancyEvent(
-        uuid_field=uuid.UUID('cd1d3a03-7b04-4a35-97f8-ee5f3eb04c8e'),
-        string_field='Just testing!'
-    )
-
-    envelope.acknowledge()
-
-    subscription_mock.acknowledge.assert_called_with([123])
+    messaging.receive(callback=mock.MagicMock())
+    assert subscription_mock.open.called


### PR DESCRIPTION
Google rewrote google-cloud-pubsub package and now it uses a new API
with async message pulling.

queue_messaging now has to use callback to handle received messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/queue-messaging/5)
<!-- Reviewable:end -->
