### PR TITLE
"Fix" memory leak in pubsub client.

### DIFF
--- a/queue_messaging/services/pubsub.py
+++ b/queue_messaging/services/pubsub.py
@@ -1,6 +1,7 @@
 import logging
 
 import tenacity
+from cached_property import cached_property
 from google.cloud import exceptions as google_cloud_exceptions
 from google.cloud import pubsub
 
@@ -39,11 +40,11 @@ retry = tenacity.retry(
 
 
 class Client:
-    @property
+    @cached_property
     def publisher(self):
         return pubsub.PublisherClient()
 
-    @property
+    @cached_property
     def subscriber(self):
         return pubsub.SubscriberClient()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages
 
 setup(
     name='queue-messaging',
-    version='0.3.5.dev0',
+    version='0.3.5.dev1',
     description='Python queue messaging library.',
     author='Social WiFi',
     author_email='it@socialwifi.com',


### PR DESCRIPTION
There is some memory leak issue in pubsub client.
Fix is ready but not deployed yet,
so I decided to cache pusub sender and publisher clients inside our Client class.

Related issue: https://github.com/googleapis/google-cloud-python/issues/6324#issuecomment-435084715

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/queue-messaging/11)
<!-- Reviewable:end -->
